### PR TITLE
Allow user to select image scaling option

### DIFF
--- a/lib/class.og-image-admin.php
+++ b/lib/class.og-image-admin.php
@@ -608,7 +608,7 @@ class Admin {
 		<div class="area--config closed collapsible">
 			<h2><?php _e( 'Plugin configuration', Plugin::TEXT_DOMAIN ); ?><span class="toggle"></span></h2>
 			<div class="inner">
-				<?php self::render_options( $fields, [ 'disabled' ] ); ?>
+				<?php self::render_options( $fields, [ 'image_scaling', 'disabled' ] ); ?>
 			</div>
 		</div>
 		<?php

--- a/lib/class.og-image-gd.php
+++ b/lib/class.og-image-gd.php
@@ -322,16 +322,31 @@ class GD {
 
 	public function save( $format, $quality ) {
 		$this->manager->file_put_contents( $this->target, '' ); // prime the file, creating all directories
+
+		$resize_option = get_option( Plugin::DEFAULTS_PREFIX . 'image_scaling', 'bicubic_fixed' );
+		$resize_key = IMG_BICUBIC_FIXED;
+		switch($resize_option) {
+			case 'bilinear_fixed':
+				$resize_key = IMG_BILINEAR_FIXED;
+				break;
+			case 'nearest_neighbor':
+				$resize_key = IMG_NEAREST_NEIGHBOUR;
+				break;
+			case 'bicubic':
+				$resize_key = IMG_BICUBIC;
+				break;
+		}
+
 		switch ( $format ) {
 			case 'jpg':
-				imagejpeg( imagescale( $this->resource, $this->manager->width, $this->manager->height, IMG_BICUBIC_FIXED ), $this->target, $quality );
+				imagejpeg( imagescale( $this->resource, $this->manager->width, $this->manager->height, $resize_key ), $this->target, $quality );
 				break;
 			case 'webp':
-				imagewebp( imagescale( $this->resource, $this->manager->width, $this->manager->height, IMG_BICUBIC_FIXED ), $this->target, $quality );
+				imagewebp( imagescale( $this->resource, $this->manager->width, $this->manager->height, $resize_key ), $this->target, $quality );
 				break;
 			case 'png':
 			default:
-				imagepng( imagescale( $this->resource, $this->manager->width, $this->manager->height, IMG_BICUBIC_FIXED ), $this->target, $quality );
+				imagepng( imagescale( $this->resource, $this->manager->width, $this->manager->height, $resize_key ), $this->target, $quality );
 				break;
 		}
 	}

--- a/lib/class.og-image-plugin.php
+++ b/lib/class.og-image-plugin.php
@@ -1547,6 +1547,19 @@ EODOC;
 
 		$options = [
 			'admin' => [
+				'image_scaling'      => [
+					'namespace' => self::DEFAULTS_PREFIX,
+					'type'      => 'select',
+					'label'     => __( 'Resizing Mode', Plugin::TEXT_DOMAIN ),
+					'comment'   => __( 'If you are having issues rendering images try using Bilinear Fixed', Plugin::TEXT_DOMAIN ),
+					'options'   => [
+						'bicubic_fixed'    => __( 'Bicubic Fixed', Plugin::TEXT_DOMAIN ),
+						'bilinear_fixed'   => __( 'Bilinear Fixed', Plugin::TEXT_DOMAIN ),
+						'nearest_neighbor' => __( 'Nearest Neighbor', Plugin::TEXT_DOMAIN ),
+						'bicubic'          => __( 'Bicubic', Plugin::TEXT_DOMAIN ),
+					],
+					'default'   => 'bicubic_fixed',
+				],
 				'disabled'      => [
 					'namespace' => self::DEFAULTS_PREFIX,
 					'type'      => 'checkbox',


### PR DESCRIPTION
This MR fixes an issue I had when trying this plugin on cPanel hosting where `IMG_BICUBIC_FIXED` has been locked down for some reason.

Following guidance on https://www.php.net/imagescale it seemed the best option would be to allow others to be picked, and this allows images to be rendered in my experience